### PR TITLE
Add sfu-announce: self-healing track re-announcement after reconnects

### DIFF
--- a/internal/signaling/client.go
+++ b/internal/signaling/client.go
@@ -18,6 +18,11 @@ import (
 const (
 	sendQueueTimeout = 2 * time.Second
 	readIdleTimeout  = 60 * time.Second
+
+	// sfu-announce bounds: a peer publishes at most audio + video + screen,
+	// and CF session/track identifiers are UUID-sized.
+	maxAnnouncedTracks = 8
+	maxSfuIDLen        = 256
 )
 
 var roomIDPattern = regexp.MustCompile(`^[a-z2-9]{3}-[a-z2-9]{4}-[a-z2-9]{3}$`)
@@ -219,6 +224,27 @@ func (c *Client) handle(env *Envelope) {
 			}
 		}
 		c.observeClientMetric(m)
+	case MsgSfuAnnounce:
+		var d SfuTracksData
+		if len(env.Data) > 0 {
+			_ = json.Unmarshal(env.Data, &d)
+		}
+		// Bound the payload: a peer publishes at most a handful of tracks
+		// (audio, video, screen). Reject junk instead of storing it — the
+		// stored set is replayed to every later joiner.
+		if d.SessionID == "" || len(d.SessionID) > maxSfuIDLen ||
+			len(d.Tracks) == 0 || len(d.Tracks) > maxAnnouncedTracks {
+			c.sendError("invalid sfu-announce")
+			return
+		}
+		for _, tr := range d.Tracks {
+			if tr.TrackName == "" || len(tr.TrackName) > maxSfuIDLen {
+				c.sendError("invalid sfu-announce")
+				return
+			}
+		}
+		slog.Info("ws_msg", "type", "sfu-announce", "peer_id", c.id, "room", c.room, "session", d.SessionID, "tracks", len(d.Tracks))
+		c.hub.AnnounceSfuTracks(c, d)
 	case MsgKnock:
 		c.hub.knock(c)
 	case MsgKnockAdmit:

--- a/internal/signaling/hub.go
+++ b/internal/signaling/hub.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"log/slog"
 	"sync"
 
 	"github.com/coder/websocket"
@@ -155,10 +156,41 @@ func (h *Hub) BroadcastSfuTracks(roomID, peerID string, data SfuTracksData) {
 	if room == nil {
 		return
 	}
+	// tracks/new is plain HTTP and can land while the peer's WebSocket is down
+	// (already removed from the room by leaveAll). Storing tracks for a
+	// non-member would create a zombie entry that gets replayed to every later
+	// joiner under a peerId nobody can attribute. The peer's own sfu-announce
+	// after reconnect restores the tracks under its new identity.
+	if room.get(peerID) == nil {
+		slog.Warn("sfu_tracks_dropped_non_member", "room", roomID, "peer_id", peerID, "session", data.SessionID)
+		return
+	}
 	merged := room.storeSfuTracks(peerID, data)
 	b, _ := json.Marshal(merged)
 	payload, _ := json.Marshal(Envelope{Type: MsgSfuTracks, Room: roomID, From: peerID, Data: b})
 	room.broadcastExcept(peerID, payload)
+}
+
+// AnnounceSfuTracks handles a client's sfu-announce: the authoritative full
+// set of tracks it currently publishes. The stored set is replaced (not
+// merged) and rebroadcast as sfu-tracks. This is the self-healing path — the
+// tracks/new interception fires only once per publish, so after a signaling
+// reconnect wipes the stored set, only the client can restore it.
+func (h *Hub) AnnounceSfuTracks(c *Client, data SfuTracksData) {
+	h.mu.Lock()
+	room := h.rooms[c.room]
+	h.mu.Unlock()
+	if room == nil {
+		c.sendErrorCode("NOT_IN_ROOM", "join a room before announcing tracks")
+		return
+	}
+	if room.get(c.id) == nil {
+		return
+	}
+	room.setSfuTracks(c.id, data)
+	b, _ := json.Marshal(data)
+	payload, _ := json.Marshal(Envelope{Type: MsgSfuTracks, Room: c.room, From: c.id, Data: b})
+	room.broadcastExcept(c.id, payload)
 }
 
 // Must be called with h.mu held.

--- a/internal/signaling/hub_test.go
+++ b/internal/signaling/hub_test.go
@@ -224,6 +224,139 @@ func TestHubBroadcastSfuTracks_NoRoom(t *testing.T) {
 	})
 }
 
+// tracks/new is plain HTTP and can land while the publishing peer's WebSocket
+// is down (already removed from the room). Storing tracks for a non-member
+// would create a zombie entry replayed to every later joiner under a peerId
+// nobody can attribute.
+func TestHubBroadcastSfuTracks_DroppedForNonMember(t *testing.T) {
+	hub := NewHub()
+	member := testClient("peer-member")
+	setTestClientState(member, "Alice", "presence-alice")
+	hub.join(member, "room-1")
+	drainEnvelopes(t, member)
+
+	hub.BroadcastSfuTracks("room-1", "peer-gone", SfuTracksData{
+		SessionID: "cf-session-stale",
+		Tracks:    []SfuTrackInfo{{TrackName: "audio"}},
+	})
+
+	if msgs := drainEnvelopes(t, member); len(msgs) != 0 {
+		t.Fatalf("expected no broadcast for non-member publisher, got %d messages", len(msgs))
+	}
+
+	// A later joiner must not receive a replay for the non-member either.
+	late := testClient("peer-late")
+	setTestClientState(late, "Bob", "presence-bob")
+	hub.join(late, "room-1")
+	if env, ok := findEnvelope(drainEnvelopes(t, late), MsgSfuTracks); ok {
+		t.Fatalf("late joiner received zombie sfu-tracks replay from %s", env.From)
+	}
+}
+
+// sfu-announce is the self-healing path: after a signaling reconnect the
+// server's stored track set is gone and only the client can restore it. The
+// announce must be stored (for join replay) and rebroadcast (for peers that
+// tore down their subscriptions on peer-left).
+func TestHubAnnounceSfuTracks_StoresAndBroadcasts(t *testing.T) {
+	hub := NewHub()
+	publisher := testClient("peer-publisher")
+	observer := testClient("peer-observer")
+	setTestClientState(publisher, "Alice", "presence-alice")
+	setTestClientState(observer, "Bob", "presence-bob")
+	hub.join(publisher, "room-1")
+	hub.join(observer, "room-1")
+	drainEnvelopes(t, publisher)
+	drainEnvelopes(t, observer)
+
+	hub.AnnounceSfuTracks(publisher, SfuTracksData{
+		SessionID: "cf-session-new",
+		Tracks:    []SfuTrackInfo{{TrackName: "track-a"}, {TrackName: "track-v"}},
+	})
+
+	env, ok := findEnvelope(drainEnvelopes(t, observer), MsgSfuTracks)
+	if !ok {
+		t.Fatal("observer should receive sfu-tracks after announce")
+	}
+	if env.From != publisher.id {
+		t.Fatalf("expected From=%s, got %s", publisher.id, env.From)
+	}
+
+	// Late joiner gets the announced set via the join replay.
+	late := testClient("peer-late")
+	setTestClientState(late, "Carol", "presence-carol")
+	hub.join(late, "room-1")
+	lateEnv, ok := findEnvelope(drainEnvelopes(t, late), MsgSfuTracks)
+	if !ok {
+		t.Fatal("late joiner should receive sfu-tracks replay after announce")
+	}
+	var data SfuTracksData
+	if err := json.Unmarshal(lateEnv.Data, &data); err != nil {
+		t.Fatalf("unmarshal replayed sfu-tracks: %v", err)
+	}
+	if data.SessionID != "cf-session-new" || len(data.Tracks) != 2 {
+		t.Fatalf("unexpected replayed announce: %+v", data)
+	}
+}
+
+// Announce replaces — it must drop track names left over from a previous CF
+// session, which the merge used by the tracks/new path would keep forever.
+func TestHubAnnounceSfuTracks_ReplacesStoredSet(t *testing.T) {
+	hub := NewHub()
+	publisher := testClient("peer-publisher")
+	setTestClientState(publisher, "Alice", "presence-alice")
+	hub.join(publisher, "room-1")
+	drainEnvelopes(t, publisher)
+
+	hub.BroadcastSfuTracks("room-1", publisher.id, SfuTracksData{
+		SessionID: "cf-session-old",
+		Tracks:    []SfuTrackInfo{{TrackName: "stale-track"}},
+	})
+	hub.AnnounceSfuTracks(publisher, SfuTracksData{
+		SessionID: "cf-session-new",
+		Tracks:    []SfuTrackInfo{{TrackName: "fresh-track"}},
+	})
+
+	late := testClient("peer-late")
+	setTestClientState(late, "Bob", "presence-bob")
+	hub.join(late, "room-1")
+	env, ok := findEnvelope(drainEnvelopes(t, late), MsgSfuTracks)
+	if !ok {
+		t.Fatal("late joiner should receive sfu-tracks replay")
+	}
+	var data SfuTracksData
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		t.Fatalf("unmarshal replayed sfu-tracks: %v", err)
+	}
+	if data.SessionID != "cf-session-new" {
+		t.Fatalf("expected replaced sessionId cf-session-new, got %q", data.SessionID)
+	}
+	if len(data.Tracks) != 1 || data.Tracks[0].TrackName != "fresh-track" {
+		t.Fatalf("announce must replace, not merge — got tracks %+v", data.Tracks)
+	}
+}
+
+// An announce from a client that is not in any room must error, not panic or
+// store state.
+func TestHubAnnounceSfuTracks_NotInRoom(t *testing.T) {
+	hub := NewHub()
+	stray := testClient("peer-stray")
+	hub.AnnounceSfuTracks(stray, SfuTracksData{
+		SessionID: "sess",
+		Tracks:    []SfuTrackInfo{{TrackName: "audio"}},
+	})
+	env, ok := findEnvelope(drainEnvelopes(t, stray), MsgError)
+	if !ok {
+		t.Fatal("expected error envelope for announce outside a room")
+	}
+	var data ErrorData
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		t.Fatalf("unmarshal error data: %v", err)
+	}
+	if data.Code != "NOT_IN_ROOM" {
+		t.Fatalf("expected code NOT_IN_ROOM, got %q", data.Code)
+	}
+}
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Knock / admit lifecycle — the bug class previously shipped as
 // "peer-joined-before-admit". A guest joining with NeedsAdmit=true must NOT

--- a/internal/signaling/message.go
+++ b/internal/signaling/message.go
@@ -20,6 +20,16 @@ const (
 	// to the Cloudflare Realtime SFU. Receivers should subscribe to the announced tracks.
 	// Sender: HTTP SFU handler. Receiver: all other peers in the room.
 	MsgSfuTracks MsgType = "sfu-tracks"
+	// MsgSfuAnnounce carries the FULL set of tracks a peer currently publishes
+	// on its CF Realtime session. Unlike the tracks/new interception (which
+	// fires once, at publish time), this is level-triggered: the browser
+	// re-sends it after every signaling reconnect, restoring the room's stored
+	// track set that leaveAll/removeSfuTracks wiped while the peer was briefly
+	// gone. Without it, a WS blip permanently hides the peer's media from
+	// every later joiner. Replaces (not merges) the stored set, then is
+	// rebroadcast to the room as sfu-tracks.
+	// Sender: browser. Receiver: server. Payload: SfuTracksData.
+	MsgSfuAnnounce MsgType = "sfu-announce"
 	// MsgClientMetric carries a single observation from the browser into the
 	// server-side Prometheus histograms. Used for measurements only the client
 	// can take — time-to-first-media, ICE gather time, etc. The server is the

--- a/internal/signaling/room.go
+++ b/internal/signaling/room.go
@@ -43,6 +43,16 @@ func (r *Room) storeSfuTracks(peerID string, data SfuTracksData) SfuTracksData {
 	return result
 }
 
+// setSfuTracks replaces the peer's stored track set wholesale. Used by the
+// sfu-announce path, where the client sends its complete current set —
+// replace semantics drop track names left over from a previous CF session,
+// which the merge in storeSfuTracks would keep forever.
+func (r *Room) setSfuTracks(peerID string, data SfuTracksData) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sfuTracks[peerID] = data
+}
+
 func (r *Room) removeSfuTracks(peerID string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()


### PR DESCRIPTION
## Problem

Users joining a call often received no media from peers already streaming. Root cause: the room's stored SFU track set (the source of the `sfu-tracks` join replay) was wiped whenever a publishing peer's WebSocket dropped, and nothing ever restored it — the client's re-publish after reconnect is a no-op at the HTTP level, so `BroadcastSfuTracks` never fired again. Every later joiner saw the peer's tile but pulled nothing (`failure_reason: no_tracks_announced`), even though the peer's media still flowed to Cloudflare.

## Changes

- **New `sfu-announce` message** (browser → server): the client re-sends its full published track set after every signaling reconnect. `hub.AnnounceSfuTracks` **replaces** (not merges) the stored set — dropping track names left over from a dead CF session — and rebroadcasts it as `sfu-tracks`.
- **Membership guard in `BroadcastSfuTracks`**: `tracks/new` is plain HTTP and can land while the peer's WS is down (already removed from the room). Previously this stored a zombie entry replayed to every later joiner under an unattributable peerId; now it's dropped with a `sfu_tracks_dropped_non_member` log.
- **Payload validation**: session/track-name length bounds, max 8 tracks.

## Tests

4 new hub tests: announce stores + broadcasts + replays to late joiners; announce replaces a stale merged set; non-member broadcasts are dropped with no zombie replay; announce outside a room returns `NOT_IN_ROOM`. Full `go test ./...` passes.

## Deploy note

Pairs with VaishnavGhenge/vartalaap-client `fix/sfu-announce-reliability`. Deploy the server first (an old server answers `sfu-announce` with "unknown message type" — harmless, but no self-healing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)