### PR TITLE
Serve the API on api.getsessionly.com alongside the legacy domain

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -28,7 +28,9 @@ ALLOWED_ORIGINS=https://vartalaap.vaishnavghenge.com
 ./deploy/deploy.sh
 ```
 
-That script builds the Linux binary, installs the systemd unit, installs the nginx vhost for `REDACTED_DOMAIN`, and runs Certbot to enable HTTPS.
+That script builds the Linux binary, installs the systemd unit, installs the nginx vhost for `$DEPLOY_DOMAIN`, and runs Certbot to enable HTTPS.
+
+Set `DEPLOY_ALT_DOMAINS` (space-separated) in `deploy/.env.deploy` to serve extra hostnames from the same vhost and certificate — used while migrating the API to `api.getsessionly.com` so the old domain keeps working until the frontend env flips. Cookies are `SameSite=Strict`, so the API host must share a registrable domain with the frontend (api.getsessionly.com ↔ getsessionly.com) for auth refresh to work.
 
 ## Verify on VM
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -11,6 +11,11 @@ fi
 DEPLOY_SERVER="${DEPLOY_SERVER:?DEPLOY_SERVER is required (e.g. root@1.2.3.4)}"
 DEPLOY_SSH_KEY="${DEPLOY_SSH_KEY:-$HOME/.ssh/id_rsa}"
 DEPLOY_DOMAIN="${DEPLOY_DOMAIN:?DEPLOY_DOMAIN is required (e.g. api.example.com)}"
+# Optional space-separated extra hostnames served by the same vhost/cert
+# (e.g. "api.getsessionly.com" during a domain migration). The cert lineage
+# stays under DEPLOY_DOMAIN — certbot --expand adds the alt names to it, so
+# the ssl_certificate paths in the nginx template remain valid.
+DEPLOY_ALT_DOMAINS="${DEPLOY_ALT_DOMAINS:-}"
 
 SSH="ssh -i $DEPLOY_SSH_KEY -o ServerAliveInterval=30 -o ConnectTimeout=15"
 BIN_NAME="vartalaap"
@@ -23,7 +28,8 @@ GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o "$LOCAL_BIN" ./cmd/server
 echo "==> Uploading artifacts..."
 # Substitute DEPLOY_DOMAIN into the nginx template before uploading
 NGINX_TMP=$(mktemp)
-DEPLOY_DOMAIN="$DEPLOY_DOMAIN" envsubst '$DEPLOY_DOMAIN' < deploy/nginx-api.conf > "$NGINX_TMP"
+DEPLOY_DOMAIN="$DEPLOY_DOMAIN" DEPLOY_ALT_DOMAINS="$DEPLOY_ALT_DOMAINS" \
+  envsubst '$DEPLOY_DOMAIN $DEPLOY_ALT_DOMAINS' < deploy/nginx-api.conf > "$NGINX_TMP"
 
 scp -i "$DEPLOY_SSH_KEY" -o ServerAliveInterval=30 -o ConnectTimeout=15 \
   "$LOCAL_BIN" deploy/vartalaap.service .env "$DEPLOY_SERVER:/tmp/"
@@ -32,7 +38,7 @@ scp -i "$DEPLOY_SSH_KEY" -o ServerAliveInterval=30 -o ConnectTimeout=15 \
 rm "$NGINX_TMP"
 
 echo "==> Installing and restarting service..."
-$SSH "$DEPLOY_SERVER" DEPLOY_DOMAIN="$DEPLOY_DOMAIN" bash <<'REMOTE'
+$SSH "$DEPLOY_SERVER" DEPLOY_DOMAIN="$DEPLOY_DOMAIN" DEPLOY_ALT_DOMAINS="$DEPLOY_ALT_DOMAINS" bash <<'REMOTE'
   set -euo pipefail
   if ! id -u vartalaap >/dev/null 2>&1; then
     useradd -r -s /bin/false vartalaap
@@ -50,7 +56,9 @@ $SSH "$DEPLOY_SERVER" DEPLOY_DOMAIN="$DEPLOY_DOMAIN" bash <<'REMOTE'
   systemctl daemon-reload
   systemctl enable vartalaap
   systemctl restart vartalaap
-  certbot --nginx -d "$DEPLOY_DOMAIN" --non-interactive --agree-tos --register-unsafely-without-email || true
+  CERT_DOMAINS=(-d "$DEPLOY_DOMAIN")
+  for alt in $DEPLOY_ALT_DOMAINS; do CERT_DOMAINS+=(-d "$alt"); done
+  certbot --nginx "${CERT_DOMAINS[@]}" --expand --non-interactive --agree-tos --register-unsafely-without-email || true
   systemctl reload nginx
   sleep 2
   systemctl is-active vartalaap

--- a/deploy/nginx-api.conf
+++ b/deploy/nginx-api.conf
@@ -1,5 +1,5 @@
 server {
-    server_name ${DEPLOY_DOMAIN};
+    server_name ${DEPLOY_DOMAIN} ${DEPLOY_ALT_DOMAINS};
 
     client_max_body_size 25M;
 
@@ -25,11 +25,7 @@ server {
 }
 
 server {
-    if ($host = ${DEPLOY_DOMAIN}) {
-        return 301 https://$host$request_uri;
-    }
-
     listen 80;
-    server_name ${DEPLOY_DOMAIN};
-    return 404;
+    server_name ${DEPLOY_DOMAIN} ${DEPLOY_ALT_DOMAINS};
+    return 301 https://$host$request_uri;
 }


### PR DESCRIPTION
## Why

The refresh cookie is `SameSite=Strict`, but the production frontend (getsessionly.com) and the API (api.vartalaap.vaishnavghenge.com) are **cross-site** — the cookie was never sent from production pages, so every session silently died 15 minutes after login. This is the root cause behind the 2026-06-11 silent-call incident (see vartalaap-client#37 for the client-side hardening). First-party hosting (`api.getsessionly.com`) fixes refresh in all browsers, including Safari/Firefox which block third-party cookies regardless of SameSite.

## Changes

- `deploy.sh`: new optional `DEPLOY_ALT_DOMAINS` (space-separated, set in untracked `.env.deploy`) — extra hostnames added to the nginx `server_name` and to the certificate via `certbot --expand`. Cert lineage stays under `DEPLOY_DOMAIN`, so the templated `ssl_certificate` paths stay valid and `nginx -t` passes before certbot runs.
- `nginx-api.conf`: both server blocks accept the alt domains; the port-80 block now redirects all named hosts to https.
- README note documenting the migration and the SameSite constraint.

## Already deployed & verified

- `https://api.getsessionly.com/healthz` → 200, `https://api.vartalaap.vaishnavghenge.com/healthz` → 200 (zero downtime)
- One cert now covers both names; CORS preflight from `https://getsessionly.com` → 204

## Remaining cutover step

Flip `NEXT_PUBLIC_SERVER_DOMAIN` to `api.getsessionly.com` in Vercel and redeploy the frontend. The legacy domain keeps working until then (and after, for old tabs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)